### PR TITLE
Potential fix for code scanning alert no. 12: User-controlled bypass of sensitive method

### DIFF
--- a/src/Kulku.Web/Kulku.Web.Admin/Components/Account/Pages/Manage/ExternalLogins.razor
+++ b/src/Kulku.Web/Kulku.Web.Admin/Components/Account/Pages/Manage/ExternalLogins.razor
@@ -81,9 +81,6 @@
 	[SupplyParameterFromForm]
 	private string? ProviderKey { get; set; }
 
-	[SupplyParameterFromQuery]
-	private string? Action { get; set; }
-
 	protected override async Task OnInitializedAsync()
 	{
 		user = await UserManager.GetUserAsync(HttpContext.User);
@@ -106,7 +103,8 @@
 
 		showRemoveButton = passwordHash is not null || currentLogins.Count > 1;
 
-		if (HttpMethods.IsGet(HttpContext.Request.Method) && Action == LinkLoginCallbackAction)
+		if (HttpMethods.IsGet(HttpContext.Request.Method)
+			&& string.Equals(HttpContext.Request.Path, "/Account/Manage/LinkExternalLogin", StringComparison.OrdinalIgnoreCase))
 		{
 			await OnGetLinkLoginCallbackAsync();
 		}


### PR DESCRIPTION
Problem in .NET autogenerated account section:

Potential fix for [https://github.com/arawnik/Kulku/security/code-scanning/12](https://github.com/arawnik/Kulku/security/code-scanning/12)

General fix: remove user-controlled query parameters from authorization/authentication flow control decisions. Use server-controlled indicators (endpoint path and method), and keep user input only as data processed inside validated handlers.

Best fix here without changing intended functionality: stop using `Action` query param as the gate and instead detect the callback endpoint via request path + GET method. In this component, the callback target is `Account/Manage/LinkExternalLogin` (already used in the form action). So, in `OnInitializedAsync`, replace:

- `if (HttpMethods.IsGet(HttpContext.Request.Method) && Action == LinkLoginCallbackAction)`

with a check that `HttpContext.Request.Path` equals `/Account/Manage/LinkExternalLogin` (case-insensitive) and method is GET, then call `OnGetLinkLoginCallbackAsync()`.

Also remove the now-unused `[SupplyParameterFromQuery] private string? Action { get; set; }` property.

File to change:
- `src/Kulku.Web/Kulku.Web.Admin/Components/Account/Pages/Manage/ExternalLogins.razor`
  - remove `Action` query-bound property (lines around 84–85)
  - update conditional in `OnInitializedAsync` (lines around 109–112)

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
